### PR TITLE
Add vigo local info page

### DIFF
--- a/djangocon_2024/content/about/information/0vigo.md
+++ b/djangocon_2024/content/about/information/0vigo.md
@@ -1,0 +1,9 @@
+title: vigo
+layout: simple
+
+How to get to Vigo?
+
+* [2024@djangocon.eu](mailto:2024@djangocon.eu)
+* [sponsors@djangocon.eu](mailto:sponsors@djangocon.eu)
+* [content@djangocon.eu](mailto:content@djangocon.eu)
+* [conduct@djangocon.eu](mailto:conduct@djangocon.eu)

--- a/djangocon_2024/content/about/information/0vigo.md
+++ b/djangocon_2024/content/about/information/0vigo.md
@@ -1,9 +1,0 @@
-title: vigo
-layout: simple
-
-How to get to Vigo?
-
-* [2024@djangocon.eu](mailto:2024@djangocon.eu)
-* [sponsors@djangocon.eu](mailto:sponsors@djangocon.eu)
-* [content@djangocon.eu](mailto:content@djangocon.eu)
-* [conduct@djangocon.eu](mailto:conduct@djangocon.eu)

--- a/djangocon_2024/content/information/vigo/0vigo.md
+++ b/djangocon_2024/content/information/vigo/0vigo.md
@@ -1,0 +1,15 @@
+title: vigo
+layout: simple
+
+In the heart of "Rias Baixas" (Lower Rias), Vigo is the largest city in Galicia. Originally a fishing village, it is now known as the "Gateway to the Atlantic". It is a city with a great cultural and gastronomic offer, with a wide variety of restaurants and bars where you can taste some of the best seafood in the world. 
+
+Nowadays a industrial city but also with a lot of life, with a great nightlife and many of leisure activities.
+
+<iframe width="560" height="315" src="https://www.youtube.com/embed/yv0QRtUnfHE?si=9OWWdqfHIasWLmi8" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
+
+You can check some of them in the following links:
+
+* [Vigo in a day](https://www.turismodevigo.org/en/vigo-day)
+* [The Crazy Tourist](https://www.thecrazytourist.com/15-best-things-vigo-spain/)
+* [TripAdvisor](https://www.tripadvisor.com/Attractions-g187509-Activities-Vigo_Province_of_Pontevedra_Galicia.html)
+* [Lonely Planet](https://www.lonelyplanet.com/spain/galicia/vigo)

--- a/djangocon_2024/content/information/vigo/1getting_to_vigo.md
+++ b/djangocon_2024/content/information/vigo/1getting_to_vigo.md
@@ -1,0 +1,31 @@
+title: Getting to Vigo
+layout: simple
+
+
+Getting to Vigo is very easy; you can reach the city’s centre from Madrid, A Coruña, Santiago de Compostela or the north of Portugal. It has motorway and train connections with Madrid and other cities, like Bilbao. Moreover, the Peinador Airport has connections with Spain’s main cities and several international destinations.
+
+<iframe src="https://www.google.com/maps/embed?pb=!1m18!1m12!1m3!1d47271.28173860591!2d-8.7254259!3d42.22608915!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0xd2f621461b2c193%3A0x7b441dad174bd49f!2sVigo%2C%20Pontevedra!5e0!3m2!1sen!2ses!4v1701966445881!5m2!1sen!2ses" width="600" height="450" style="border:0;" allowfullscreen="" loading="lazy" referrerpolicy="no-referrer-when-downgrade"></iframe>
+
+### By plane, Vigo's Airport
+
+Peinador, Vigo’s Airport, is Galicia’s southern airport and is only 20 minutes from the city centre. Flying is the fastest option when travelling to Vigo from Madrid, Barcelona, Bilbao, Tenerife Norte and Gran Canaria in Spain, but also internationally from London (Stansted), since these cities have direct flights to Vigo. Once you’ve landed, you can take a taxi or bus to the city centre. 
+The quickest way to get to the city centre is by taxi, which costs around 25 euros. If you prefer to take the bus, you can take the L9A line, which runs every 30 minutes from 7:00 to 23:00. The bus stop is located in front of the airport’s main entrance. The ticket costs 1.35 euros and can be purchased on the bus. The bus will take you to the city centre in 40 minutes.
+
+Website: [Vigo's Airport](https://www.aena.es/en/vigo-airport/index.html)
+
+### By train
+
+Vigo has two railway stations: URZÁIZ where departs the AVE (Spain’s high-speed train), and GUIXAR, located in Areal St., bouth of them right in the city centre. 
+
+Website: [Renfe](https://www.renfe.com/)
+
+### By car or bus
+
+The most common way of travelling to Vigo is by car. The city’s good connections make it easy to get to Vigo on the motorway from Madrid, Santiago, A Coruña and Porto.
+
+There are three main motorway entry routes:
+
+The Autovía del Noroeste (A-6) and the Autovía das Rías Baixas (A-52) motorways connect Vigo and Madrid. If you’re travelling to Vigo from Portugal, you can take the A-3 motorway, which links Porto, Lisbon and Braga with the Spanish border and then take AP-9 and A-55, which will take you straight to the centre of Vigo.
+
+Getting to Vigo by bus is also a possibility. There are direct bus lines to Vigo from Madrid, Barcelona and many other Spanish cities. The bus station is located in the city centre, in Travesía de Vigo St.  Furthermore, there are international bus lines that will take you to Vigo from Portugal, France, Switzerland, Belgium, Holland, Denmark and Germany.
+

--- a/djangocon_2024/content/information/vigo/2getting_around.md
+++ b/djangocon_2024/content/information/vigo/2getting_around.md
@@ -1,0 +1,18 @@
+title: Getting around
+layout: simple
+
+Vigo is a small city and you can walk almost everywhere although Vigo is well know for its hills, so be prepared to walk up and down. Nowadays, there are a lot of electric ladder and escalators to help you with that.
+To get around in Vigo and if you want to go to nearby beaches, the best option is public transportation, bus or taxi.
+
+
+### By bus
+
+Vitrasa is the public urban bus in Vigo. You can use the [Moovit app](https://moovitapp.com/) to plan your trip. and to be informed.
+
+* [Urban bus - Vitrasa](https://www.vitrasa.es/en/)
+
+### By taxi
+
+If you prefer a little more flexibility, you won’t have any trouble finding a taxi in Vigo. This is a very comfortable option to move about the centre of Vigo and its neighbourhoods. They have reasonable rates and will allow you to get around quickly.   
+
+* [Taxi - Tlf 984700000 ](http://radiotaxi470000.com/)

--- a/djangocon_2024/site/utils/context_processors.py
+++ b/djangocon_2024/site/utils/context_processors.py
@@ -36,6 +36,7 @@ def links(request):
                 'submenu': {
                     'Contact': '/about/contact/',
                     'Credits': '/about/credits/',
+                    'Information': '/about/information/',
                 },
             },
         },

--- a/djangocon_2024/site/utils/context_processors.py
+++ b/djangocon_2024/site/utils/context_processors.py
@@ -19,6 +19,12 @@ def links(request):
                     'Sponsorship': '/sponsors/sponsorship/',
                 },
             },
+            'Information': {
+                'dropdown': 'true',
+                'submenu': {
+                    'Vigo': '/information/vigo/',
+                },
+            },
             'Conduct': {
                 'dropdown': 'true',
                 'submenu': {
@@ -36,7 +42,6 @@ def links(request):
                 'submenu': {
                     'Contact': '/about/contact/',
                     'Credits': '/about/credits/',
-                    'Information': '/about/information/',
                 },
             },
         },


### PR DESCRIPTION
Hi! this is a **first pass** to the Vigo's info page as has been requested by @Luis Vaz

Please, feel free to modify/change whatever you think it's appropriate, I've created the page within the same path "Information / City" and following the  same structure as in the [Django 2022 website](https://2022.djangocon.eu/information/porto/), so move it to wherever you think fits better.

Here a screenshot

<img width="424" alt="Screenshot 2023-12-07 at 17 41 38" src="https://github.com/djangocon/2024.djangocon.eu/assets/4062867/77647f6c-57fd-4c6d-ba78-e15492a7985a">

I'll share it with a few people from @pythonvigo to review it.