### PR TITLE
Removed EPS logo  from sponsors.md

### DIFF
--- a/djangocon_2024/content/sponsors/sponsors/sponsors.md
+++ b/djangocon_2024/content/sponsors/sponsors/sponsors.md
@@ -19,9 +19,6 @@ layout: simple
 
 ##### Grants
 
-<img src="{% static 'images/sponsors/eps.png' %}" class='sponsor large'
-           alt="EPS Logo">
-
 [![dsf](/static/images/sponsors/dsf.png){:class='sponsor large'}](https://evolutio.pt/){:target="\_blank"}
 
 [![Eps](/static/images/sponsors/eps.png){:class='sponsor large'}](https://europython-society.org/){:target="\_blank"}


### PR DESCRIPTION
saw some error on the sponsors page concerning EPS LOGO not viewing and i fixed  it
![image](https://github.com/djangocon/2024.djangocon.eu/assets/66005635/53964ead-3ccb-451b-9ae6-47ce6698cbea)
