### PR TITLE
Change repo links from 2022 repo to 2024 repo

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,7 +6,7 @@ The following is a set of guidelines for contributing to DjangoCon Europe 2024.
 
 ## How Can I Help?
 
-Start looking through the [Issues](https://github.com/djangocon/2022.djangocon.eu/issues) and watch out for any issues with the green label [`up-for-grabs`](https://github.com/djangocon/2022.djangocon.eu/labels/up-for-grabs). Issues marked with this label haven't been assigned to anyone yet and we would love for you to work on them.
+Start looking through the [Issues](https://github.com/djangocon/2024.djangocon.eu/issues) and watch out for any issues with the green label [`up-for-grabs`](https://github.com/djangocon/2024.djangocon.eu/labels/up-for-grabs). Issues marked with this label haven't been assigned to anyone yet and we would love for you to work on them.
 
 ## Difficulty Levels
 


### PR DESCRIPTION
### What does this PR do?
- Fix issue tracking links 

### What tasks were done?
- Change issue tracking links from pointing to https://github.com/djangocon/2022.djangocon.eu to https://github.com/djangocon/2024.djangocon.eu