### PR TITLE
Update Mastodon link in social_media context processor

### DIFF
--- a/djangocon_2024/site/utils/context_processors.py
+++ b/djangocon_2024/site/utils/context_processors.py
@@ -53,7 +53,7 @@ def links(request):
         },
         "social_media": {
             "twitter": "https://twitter.com/DjangoConEurope/",
-            "fosstodon": "https://fosstodon.org/@djangocon/",
+            "fosstodon": "https://fosstodon.org/@djangoconeurope/",
             "slack": "https://join.slack.com/t/djangoconeurope/shared_invite/zt-1gjg5lqkz-qVQkNnhjztXVme7TQ7ziQA",
             "youtube": "https://youtube.com/user/djangoconeurope/",
             "linkedin": "https://linkedin.com/company/djangocon-europe/",


### PR DESCRIPTION
the fosstodon link was directing to djangoconus and not europe 
fixed that 