### PR TITLE
Add pop-up script for home page in home.html template

### DIFF
--- a/djangocon_2024/templates/pages/home.html
+++ b/djangocon_2024/templates/pages/home.html
@@ -4,6 +4,13 @@
 {% block content %}
 
 {# HOME-HEADER #}
+
+<!-- script for pop starts -->
+<script src="https://static.elfsight.com/platform/platform.js" data-use-service-core defer></script>
+<div class="elfsight-app-8f8c9b45-32fa-42fd-86de-57dac5995e26" data-elfsight-app-lazy></div>
+
+
+<!-- script for pop up ends -->
 <div class="container text-center">
   <div id="dates_title"></div>
 </div>


### PR DESCRIPTION
On home page load there will be a pop up announcing our tickets availability and Scheduled talks prompt 

![image](https://github.com/djangocon/2024.djangocon.eu/assets/66005635/b9395ea3-dd91-4b05-9a0e-e9285d6c0b27)
